### PR TITLE
CFE_UY: Add cfe_logs persistence and model relations

### DIFF
--- a/app/Models/CfeLog.php
+++ b/app/Models/CfeLog.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2025. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Models;
+
+use App\Models\Company;
+use App\Models\Invoice;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $company_id
+ * @property int $invoice_id
+ * @property string|null $external_invoice_id
+ * @property string $direction
+ * @property string|null $provider_status
+ * @property int|null $provider_code
+ * @property string|null $provider_description
+ * @property int|null $cfe_tipo
+ * @property string|null $cfe_serie
+ * @property int|null $cfe_numero
+ * @property string|null $cae_id
+ * @property int|null $cae_dnro
+ * @property int|null $cae_hnro
+ * @property \Carbon\Carbon|null $cae_vto
+ * @property string|null $hash
+ * @property string|null $link_qr
+ * @property string|null $imagen_qr_base64
+ * @property string|null $xml_firmado
+ * @property object|null $request_payload
+ * @property object|null $response_payload
+ * @property string|null $trace_id
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ * @property-read \App\Models\Company $company
+ * @property-read \App\Models\Invoice $invoice
+ */
+class CfeLog extends Model
+{
+    public $timestamps = true;
+
+    protected $casts = [
+        'cae_vto' => 'date',
+        'request_payload' => 'object',
+        'response_payload' => 'object',
+    ];
+
+    protected $guarded = ['id'];
+
+    public function company()
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function invoice()
+    {
+        return $this->belongsTo(Invoice::class);
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -144,6 +144,7 @@ use Laracasts\Presenter\PresentableTrait;
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Activity> $activities
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Location> $locations
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\VerifactuLog> $verifactu_logs
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\CfeLog> $cfe_logs
  * @property-read int|null $activities_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Activity> $all_activities
  * @property-read int|null $all_activities_count
@@ -442,6 +443,11 @@ class Company extends BaseModel
     public function verifactu_logs(): HasMany
     {
         return $this->hasMany(VerifactuLog::class)->orderBy('id', 'DESC');
+    }
+
+    public function cfe_logs(): HasMany
+    {
+        return $this->hasMany(CfeLog::class)->orderBy('id', 'DESC');
     }
 
     public function task_schedulers(): HasMany

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -134,6 +134,7 @@ use App\Utils\Number;
  * @property-read \App\Models\Location|null $location
  * @property-read \App\Models\Quote|null $quote
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\VerifactuLog> $verifactu_logs
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\CfeLog> $cfe_logs
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\TransactionEvent> $transaction_events
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Activity> $activities
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\CompanyLedger> $company_ledger
@@ -424,6 +425,11 @@ class Invoice extends BaseModel
     public function verifactu_logs(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(VerifactuLog::class)->orderBy('id', 'desc');
+    }
+
+    public function cfe_logs(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(CfeLog::class)->orderBy('id', 'desc');
     }
 
     public function tasks(): \Illuminate\Database\Eloquent\Relations\HasMany

--- a/database/migrations/2026_02_14_000000_create_cfe_logs_table.php
+++ b/database/migrations/2026_02_14_000000_create_cfe_logs_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cfe_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('company_id')->index();
+            $table->unsignedInteger('invoice_id')->index();
+            $table->string('external_invoice_id')->nullable()->index();
+
+            $table->string('direction')->default('sent');
+            $table->string('provider_status')->nullable();
+            $table->integer('provider_code')->nullable();
+            $table->string('provider_description')->nullable();
+
+            $table->integer('cfe_tipo')->nullable();
+            $table->string('cfe_serie')->nullable();
+            $table->integer('cfe_numero')->nullable();
+
+            $table->string('cae_id')->nullable();
+            $table->integer('cae_dnro')->nullable();
+            $table->integer('cae_hnro')->nullable();
+            $table->date('cae_vto')->nullable();
+
+            $table->string('hash')->nullable();
+            $table->text('link_qr')->nullable();
+            $table->longText('imagen_qr_base64')->nullable();
+            $table->longText('xml_firmado')->nullable();
+
+            $table->json('request_payload')->nullable();
+            $table->json('response_payload')->nullable();
+            $table->string('trace_id')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cfe_logs');
+    }
+};


### PR DESCRIPTION
## Summary
- Creates `cfe_logs` migration with all CFE regulatory fields: provider status/code, CFE tipo/serie/numero, CAE fields, hash, QR link/base64, signed XML, request/response JSON payloads, trace_id
- Adds `CfeLog` model following `VerifactuLog` patterns (guarded, casts, belongsTo)
- Adds `cfe_logs()` hasMany relations on `Company` and `Invoice` models

## Test plan
- [ ] Migration up creates `cfe_logs` table with correct schema
- [ ] Migration down drops the table
- [ ] `$invoice->cfe_logs()` and `$company->cfe_logs()` relations work
- [ ] JSON fields cast to objects correctly
- [ ] No regressions in existing Verifactu relations

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CFE logging system to track and record all CFE-related operations and their responses, now integrated with companies and invoices for improved audit trail and record-keeping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->