### PR TITLE
CFE_UY: Add company settings support and guardrails

### DIFF
--- a/app/Http/Requests/Company/UpdateCompanyRequest.php
+++ b/app/Http/Requests/Company/UpdateCompanyRequest.php
@@ -218,6 +218,10 @@ class UpdateCompanyRequest extends Request
                 $settings['e_invoice_type'] = 'VERIFACTU';
             }
 
+            if($this->company->getSetting('e_invoice_type') == 'CFE_UY') {
+                $settings['e_invoice_type'] = 'CFE_UY';
+            }
+
         }
 
         if(isset($settings['e_invoice_type']) && $settings['e_invoice_type'] == 'VERIFACTU' && $this->company->verifactuEnabled()) {

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -1062,4 +1062,18 @@ class Company extends BaseModel
             return $this->getSetting('e_invoice_type') == 'VERIFACTU';
         });
     }
+
+    /**
+     * cfeUyEnabled
+     *
+     * Returns a flag if the current company is using CFE_UY as the e-invoice provider
+     *
+     * @return bool
+     */
+    public function cfeUyEnabled(): bool
+    {
+        return once(function () {
+            return $this->getSetting('e_invoice_type') == 'CFE_UY';
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `cfeUyEnabled()` helper method on Company model using `once()` caching pattern (mirrors `verifactuEnabled()`)
- Adds hosted platform lock: once `e_invoice_type=CFE_UY` is set, it cannot be changed on hosted platform
- No changes needed to `CompanySettings.php` - `e_invoice_type` is already a string property that accepts any value

## Test plan
- [ ] `settings.e_invoice_type=CFE_UY` persists correctly via API
- [ ] `$company->cfeUyEnabled()` returns true when CFE_UY is set
- [ ] On hosted platform, CFE_UY cannot be changed to another type
- [ ] Existing e-invoice types still persist and work
- [ ] No regression in VERIFACTU lock behavior

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)