### PR TITLE
CFE_UY: Implement external service adapter

### DIFF
--- a/app/Services/EDocument/Standards/CfeUy/Client.php
+++ b/app/Services/EDocument/Standards/CfeUy/Client.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2025. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Services\EDocument\Standards\CfeUy;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\Response;
+
+class Client
+{
+    private string $base_url;
+    private string $token;
+    private int $timeout;
+    private bool $verify_ssl;
+
+    public function __construct()
+    {
+        $this->base_url = rtrim(config('services.cfe_uy.base_url', ''), '/');
+        $this->token = config('services.cfe_uy.token', '');
+        $this->timeout = (int) config('services.cfe_uy.timeout', 30);
+        $this->verify_ssl = (bool) config('services.cfe_uy.verify_ssl', true);
+    }
+
+    /**
+     * Emit a CFE document via the external xml-cfe service.
+     *
+     * @param array $payload The mapped CFE request payload
+     * @return Response
+     */
+    public function emit(array $payload): Response
+    {
+        nlog("CFE_UY: Emitting CFE to {$this->base_url}/v1/cfe/emit");
+
+        return Http::withToken($this->token)
+            ->withHeaders([
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ])
+            ->withOptions([
+                'verify' => $this->verify_ssl,
+                'timeout' => $this->timeout,
+            ])
+            ->post("{$this->base_url}/v1/cfe/emit", $payload);
+    }
+
+    /**
+     * Check the status of a previously submitted CFE.
+     *
+     * @param string $external_id The external invoice ID
+     * @return Response
+     */
+    public function status(string $external_id): Response
+    {
+        nlog("CFE_UY: Checking status for {$external_id}");
+
+        return Http::withToken($this->token)
+            ->withHeaders([
+                'Accept' => 'application/json',
+            ])
+            ->withOptions([
+                'verify' => $this->verify_ssl,
+                'timeout' => $this->timeout,
+            ])
+            ->get("{$this->base_url}/v1/cfe/status/{$external_id}");
+    }
+}

--- a/app/Services/EDocument/Standards/CfeUy/Mapper.php
+++ b/app/Services/EDocument/Standards/CfeUy/Mapper.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2025. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Services\EDocument\Standards\CfeUy;
+
+use App\Models\Invoice;
+use App\Models\Company;
+use App\Models\Client;
+
+class Mapper
+{
+    private Invoice $invoice;
+    private Company $company;
+    private Client $client;
+    private array $tax_map;
+
+    public function __construct(Invoice $invoice)
+    {
+        $this->invoice = $invoice;
+        $this->company = $invoice->company;
+        $this->client = $invoice->client;
+        $this->tax_map = config('services.cfe_uy.tax_map', []);
+    }
+
+    /**
+     * Map the Invoice Ninja invoice into the xml-cfe service request contract.
+     *
+     * @return array The full request payload for POST /v1/cfe/emit
+     */
+    public function toPayload(): array
+    {
+        return [
+            'idempotency_key' => $this->buildIdempotencyKey(),
+            'external_invoice_id' => $this->invoice->hashed_id,
+            'document' => $this->mapDocument(),
+            'emisor' => $this->mapEmisor(),
+            'receptor' => $this->mapReceptor(),
+            'items' => $this->mapItems(),
+            'meta' => $this->mapMeta(),
+        ];
+    }
+
+    /**
+     * Build idempotency key from immutable-ish tuple.
+     */
+    private function buildIdempotencyKey(): string
+    {
+        return implode(':', [
+            $this->company->company_key,
+            $this->invoice->id,
+            $this->invoice->updated_at->timestamp,
+        ]);
+    }
+
+    /**
+     * Determine the CFE type: 111 (e-Factura) if client has RUT, else 101 (e-Ticket).
+     */
+    public function resolveTipoCfe(): int
+    {
+        $vat_number = $this->client->vat_number ?? '';
+        $id_number = $this->client->id_number ?? '';
+
+        if (strlen($vat_number) >= 12 || strlen($id_number) >= 12) {
+            return 111;
+        }
+
+        return 101;
+    }
+
+    /**
+     * Map the document-level fields.
+     */
+    private function mapDocument(): array
+    {
+        return [
+            'tipo_cfe' => $this->resolveTipoCfe(),
+            'serie' => 'A',
+            'fecha_emision' => $this->invoice->date ?? now()->format('Y-m-d'),
+            'forma_pago' => $this->resolveFormaPago(),
+            'fecha_vencimiento' => $this->invoice->due_date,
+            'monto_bruto' => true,
+            'moneda' => $this->client->currency()->code ?? 'UYU',
+            'tipo_cambio' => $this->resolveTipoCambio(),
+        ];
+    }
+
+    /**
+     * Resolve payment form: 1 = contado, 2 = credito.
+     */
+    private function resolveFormaPago(): int
+    {
+        if ($this->invoice->due_date && $this->invoice->due_date > $this->invoice->date) {
+            return 2;
+        }
+        return 1;
+    }
+
+    /**
+     * Resolve exchange rate. Null for UYU.
+     */
+    private function resolveTipoCambio(): ?string
+    {
+        $currency_code = $this->client->currency()->code ?? 'UYU';
+
+        if ($currency_code === 'UYU') {
+            return null;
+        }
+
+        return $this->invoice->exchange_rate ? number_format($this->invoice->exchange_rate, 3, '.', '') : null;
+    }
+
+    /**
+     * Map company data to emisor block.
+     */
+    private function mapEmisor(): array
+    {
+        $settings = $this->company->settings;
+
+        return [
+            'rut' => $this->company->settings->vat_number ?? '',
+            'razon_social' => $settings->name ?? $this->company->present()->name(),
+            'nombre_fantasia' => $settings->name ?? '',
+            'domicilio_fiscal' => trim(implode(', ', array_filter([
+                $settings->address1 ?? '',
+                $settings->address2 ?? '',
+                $settings->city ?? '',
+                $settings->state ?? '',
+            ]))),
+            'ciudad' => $settings->city ?? '',
+            'departamento' => $settings->state ?? '',
+        ];
+    }
+
+    /**
+     * Map client data to receptor block.
+     */
+    private function mapReceptor(): array
+    {
+        $receptor = [
+            'tipo_doc_receptor' => $this->resolveReceptorDocType(),
+            'doc_receptor' => $this->client->vat_number ?: ($this->client->id_number ?: ''),
+            'razon_social' => $this->client->present()->name(),
+            'direccion' => trim(implode(', ', array_filter([
+                $this->client->address1 ?? '',
+                $this->client->address2 ?? '',
+                $this->client->city ?? '',
+                $this->client->state ?? '',
+            ]))),
+            'ciudad' => $this->client->city ?? '',
+            'departamento' => $this->client->state ?? '',
+            'pais_receptor' => $this->client->country ? $this->client->country->iso_3166_3 : 'URY',
+        ];
+
+        return $receptor;
+    }
+
+    /**
+     * Resolve receptor document type.
+     * 2 = RUC, 3 = CI, 4 = Otros, 5 = Pasaporte, 6 = DNI, 7 = NIFE
+     */
+    private function resolveReceptorDocType(): int
+    {
+        $vat = $this->client->vat_number ?? '';
+
+        if (strlen($vat) >= 12) {
+            return 2; // RUC
+        }
+
+        $id = $this->client->id_number ?? '';
+        if (strlen($id) >= 6 && strlen($id) <= 8) {
+            return 3; // CI
+        }
+
+        return 4; // Otros
+    }
+
+    /**
+     * Map invoice line items.
+     */
+    private function mapItems(): array
+    {
+        $items = [];
+        $line_items = $this->invoice->line_items ?? [];
+
+        foreach ($line_items as $item) {
+            $items[] = [
+                'indicador_facturacion' => $this->resolveIndFact($item),
+                'nombre' => $item->product_key ?: ($item->notes ?: 'Item'),
+                'descripcion' => $item->notes ?? '',
+                'cantidad' => number_format($item->quantity, 4, '.', ''),
+                'precio_unitario' => number_format($item->cost, 4, '.', ''),
+                'descuento' => number_format($item->discount ?? 0, 2, '.', ''),
+                'es_porcentaje_descuento' => $item->is_amount_discount ? false : true,
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Map tax rate to IndFact (indicador de facturacion).
+     *
+     * Uses the config-driven tax map:
+     *   22% -> 3 (basica)
+     *   10% -> 2 (minima)
+     *   0% with tax name -> 1 (exento)
+     *   0% no tax -> 6 (no facturable)
+     *
+     * @throws \RuntimeException if tax rate is unmapped
+     */
+    public function resolveIndFact(object $item): int
+    {
+        $rate = round((float)($item->tax_rate1 ?? 0), 0);
+        $tax_name = $item->tax_name1 ?? '';
+
+        $rate_key = (string) $rate;
+
+        if (isset($this->tax_map[$rate_key])) {
+            return (int) $this->tax_map[$rate_key];
+        }
+
+        if ($rate == 0 && strlen($tax_name) > 0) {
+            return (int) ($this->tax_map['0_exempt'] ?? 1);
+        }
+
+        if ($rate == 0) {
+            return (int) ($this->tax_map['0_none'] ?? 6);
+        }
+
+        throw new \RuntimeException(
+            "CFE_UY: Unmapped tax rate {$rate}% for item '{$item->product_key}'. Configure services.cfe_uy.tax_map."
+        );
+    }
+
+    /**
+     * Map metadata block.
+     */
+    private function mapMeta(): array
+    {
+        return [
+            'company_key' => $this->company->company_key,
+            'invoice_number' => $this->invoice->number,
+            'environment' => app()->environment(),
+        ];
+    }
+}

--- a/app/Services/EDocument/Standards/CfeUy/ResponseProcessor.php
+++ b/app/Services/EDocument/Standards/CfeUy/ResponseProcessor.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2025. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Services\EDocument\Standards\CfeUy;
+
+use Illuminate\Http\Client\Response;
+
+class ResponseProcessor
+{
+    /**
+     * Process a successful emission response from xml-cfe service.
+     *
+     * Returns a normalized array regardless of success/failure.
+     *
+     * @param Response $response
+     * @return array{success: bool, status: string, message: string, cfe: array|null, provider: array, trace_id: string|null, retryable: bool, raw: array}
+     */
+    public function process(Response $response): array
+    {
+        if ($response->failed()) {
+            return $this->processHttpFailure($response);
+        }
+
+        $body = $response->json();
+
+        if (!is_array($body)) {
+            return $this->buildResult(
+                success: false,
+                status: 'ERROR',
+                message: 'Malformed response: not valid JSON',
+                retryable: true,
+                raw: ['http_status' => $response->status(), 'body' => $response->body()],
+            );
+        }
+
+        $success = data_get($body, 'success', false);
+
+        return $this->buildResult(
+            success: $success,
+            status: data_get($body, 'status', $success ? 'EN' : 'ERROR'),
+            message: data_get($body, 'message', ''),
+            cfe: $success ? data_get($body, 'cfe') : null,
+            provider: [
+                'codigo' => data_get($body, 'provider.codigo'),
+                'descripcion' => data_get($body, 'provider.descripcion', ''),
+            ],
+            trace_id: data_get($body, 'trace_id'),
+            retryable: data_get($body, 'retryable', false),
+            raw: $body,
+        );
+    }
+
+    /**
+     * Process an HTTP-level failure (timeout, 5xx, network error, etc.).
+     */
+    private function processHttpFailure(Response $response): array
+    {
+        $status = $response->status();
+        $retryable = $status >= 500 || $status === 0;
+
+        return $this->buildResult(
+            success: false,
+            status: 'ERROR',
+            message: "HTTP {$status}: " . substr($response->body(), 0, 500),
+            retryable: $retryable,
+            raw: ['http_status' => $status, 'body' => $response->body()],
+        );
+    }
+
+    /**
+     * Build a normalized result array.
+     */
+    private function buildResult(
+        bool $success,
+        string $status,
+        string $message,
+        ?array $cfe = null,
+        array $provider = [],
+        ?string $trace_id = null,
+        bool $retryable = false,
+        array $raw = [],
+    ): array {
+        return [
+            'success' => $success,
+            'status' => $status,
+            'message' => $message,
+            'cfe' => $cfe,
+            'provider' => $provider,
+            'trace_id' => $trace_id,
+            'retryable' => $retryable,
+            'raw' => $raw,
+        ];
+    }
+}

--- a/tests/Unit/CfeUy/ClientTest.php
+++ b/tests/Unit/CfeUy/ClientTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit\CfeUy;
+
+use Tests\TestCase;
+use App\Services\EDocument\Standards\CfeUy\Client;
+use Illuminate\Support\Facades\Http;
+
+class ClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'services.cfe_uy.base_url' => 'https://cfe-test.example.com',
+            'services.cfe_uy.token' => 'test-token-123',
+            'services.cfe_uy.timeout' => 10,
+            'services.cfe_uy.verify_ssl' => false,
+        ]);
+    }
+
+    public function test_emit_sends_post_with_auth(): void
+    {
+        Http::fake([
+            'cfe-test.example.com/v1/cfe/emit' => Http::response([
+                'success' => true,
+                'status' => 'EN',
+            ], 200),
+        ]);
+
+        $client = new Client();
+        $response = $client->emit(['test' => 'payload']);
+
+        $this->assertTrue($response->successful());
+        $this->assertTrue($response->json('success'));
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://cfe-test.example.com/v1/cfe/emit'
+                && $request->hasHeader('Authorization', 'Bearer test-token-123')
+                && $request['test'] === 'payload';
+        });
+    }
+
+    public function test_status_sends_get_with_auth(): void
+    {
+        Http::fake([
+            'cfe-test.example.com/v1/cfe/status/*' => Http::response([
+                'success' => true,
+                'status' => 'EN',
+            ], 200),
+        ]);
+
+        $client = new Client();
+        $response = $client->status('ext-123');
+
+        $this->assertTrue($response->successful());
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/v1/cfe/status/ext-123')
+                && $request->hasHeader('Authorization', 'Bearer test-token-123');
+        });
+    }
+
+    public function test_emit_handles_timeout(): void
+    {
+        Http::fake([
+            'cfe-test.example.com/*' => Http::response('', 504),
+        ]);
+
+        $client = new Client();
+        $response = $client->emit(['test' => 'payload']);
+
+        $this->assertTrue($response->failed());
+        $this->assertEquals(504, $response->status());
+    }
+}

--- a/tests/Unit/CfeUy/MapperTest.php
+++ b/tests/Unit/CfeUy/MapperTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Unit\CfeUy;
+
+use Tests\TestCase;
+use App\Services\EDocument\Standards\CfeUy\Mapper;
+use Tests\MockAccountData;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class MapperTest extends TestCase
+{
+    use MockAccountData;
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->makeTestData();
+    }
+
+    public function test_tipo_cfe_101_for_client_without_rut(): void
+    {
+        $this->client->vat_number = '';
+        $this->client->id_number = '12345678';
+        $this->client->save();
+
+        $mapper = new Mapper($this->invoice);
+        $this->assertEquals(101, $mapper->resolveTipoCfe());
+    }
+
+    public function test_tipo_cfe_111_for_client_with_rut(): void
+    {
+        $this->client->vat_number = '214100010018';
+        $this->client->save();
+
+        $mapper = new Mapper($this->invoice);
+        $this->assertEquals(111, $mapper->resolveTipoCfe());
+    }
+
+    public function test_ind_fact_mapping_basica_22(): void
+    {
+        config(['services.cfe_uy.tax_map' => ['22' => 3, '10' => 2, '0_exempt' => 1, '0_none' => 6]]);
+
+        $mapper = new Mapper($this->invoice);
+        $item = (object) ['tax_rate1' => 22.0, 'tax_name1' => 'IVA', 'product_key' => 'Test'];
+
+        $this->assertEquals(3, $mapper->resolveIndFact($item));
+    }
+
+    public function test_ind_fact_mapping_minima_10(): void
+    {
+        config(['services.cfe_uy.tax_map' => ['22' => 3, '10' => 2, '0_exempt' => 1, '0_none' => 6]]);
+
+        $mapper = new Mapper($this->invoice);
+        $item = (object) ['tax_rate1' => 10.0, 'tax_name1' => 'IVA Minima', 'product_key' => 'Test'];
+
+        $this->assertEquals(2, $mapper->resolveIndFact($item));
+    }
+
+    public function test_ind_fact_mapping_exento(): void
+    {
+        config(['services.cfe_uy.tax_map' => ['22' => 3, '10' => 2, '0_exempt' => 1, '0_none' => 6]]);
+
+        $mapper = new Mapper($this->invoice);
+        $item = (object) ['tax_rate1' => 0, 'tax_name1' => 'Exento', 'product_key' => 'Test'];
+
+        $this->assertEquals(1, $mapper->resolveIndFact($item));
+    }
+
+    public function test_ind_fact_mapping_no_facturable(): void
+    {
+        config(['services.cfe_uy.tax_map' => ['22' => 3, '10' => 2, '0_exempt' => 1, '0_none' => 6]]);
+
+        $mapper = new Mapper($this->invoice);
+        $item = (object) ['tax_rate1' => 0, 'tax_name1' => '', 'product_key' => 'Test'];
+
+        $this->assertEquals(6, $mapper->resolveIndFact($item));
+    }
+
+    public function test_unmapped_tax_rate_throws(): void
+    {
+        config(['services.cfe_uy.tax_map' => ['22' => 3, '10' => 2, '0_exempt' => 1, '0_none' => 6]]);
+
+        $mapper = new Mapper($this->invoice);
+        $item = (object) ['tax_rate1' => 15.0, 'tax_name1' => 'Unknown', 'product_key' => 'TestItem'];
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unmapped tax rate');
+        $mapper->resolveIndFact($item);
+    }
+
+    public function test_full_payload_structure(): void
+    {
+        config(['services.cfe_uy.tax_map' => ['22' => 3, '10' => 2, '0_exempt' => 1, '0_none' => 6]]);
+
+        $this->client->vat_number = '';
+        $this->client->save();
+
+        $mapper = new Mapper($this->invoice);
+        $payload = $mapper->toPayload();
+
+        $this->assertArrayHasKey('idempotency_key', $payload);
+        $this->assertArrayHasKey('external_invoice_id', $payload);
+        $this->assertArrayHasKey('document', $payload);
+        $this->assertArrayHasKey('emisor', $payload);
+        $this->assertArrayHasKey('receptor', $payload);
+        $this->assertArrayHasKey('items', $payload);
+        $this->assertArrayHasKey('meta', $payload);
+
+        $this->assertEquals($this->invoice->hashed_id, $payload['external_invoice_id']);
+        $this->assertArrayHasKey('tipo_cfe', $payload['document']);
+        $this->assertArrayHasKey('rut', $payload['emisor']);
+        $this->assertArrayHasKey('razon_social', $payload['receptor']);
+    }
+}

--- a/tests/Unit/CfeUy/ResponseProcessorTest.php
+++ b/tests/Unit/CfeUy/ResponseProcessorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Unit\CfeUy;
+
+use Tests\TestCase;
+use App\Services\EDocument\Standards\CfeUy\ResponseProcessor;
+use Illuminate\Support\Facades\Http;
+
+class ResponseProcessorTest extends TestCase
+{
+    private ResponseProcessor $processor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->processor = new ResponseProcessor();
+    }
+
+    public function test_successful_emission_response(): void
+    {
+        Http::fake([
+            '*' => Http::response([
+                'success' => true,
+                'status' => 'EN',
+                'message' => 'Operacion exitosa',
+                'cfe' => [
+                    'tipo' => 101,
+                    'serie' => 'A',
+                    'numero' => 833,
+                    'cae_id' => '90253805312',
+                    'cae_dnro' => 801,
+                    'cae_hnro' => 1000,
+                    'cae_vto' => '2027-08-28',
+                    'hash' => 'abc123',
+                    'link_qr' => 'https://example.com/qr',
+                ],
+                'provider' => [
+                    'codigo' => 0,
+                    'descripcion' => 'Operacion exitosa',
+                ],
+                'trace_id' => 'test-trace-id',
+            ], 200),
+        ]);
+
+        $response = Http::get('https://example.com/test');
+        $result = $this->processor->process($response);
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals('EN', $result['status']);
+        $this->assertEquals('Operacion exitosa', $result['message']);
+        $this->assertNotNull($result['cfe']);
+        $this->assertEquals(101, $result['cfe']['tipo']);
+        $this->assertEquals('90253805312', $result['cfe']['cae_id']);
+        $this->assertEquals(0, $result['provider']['codigo']);
+        $this->assertEquals('test-trace-id', $result['trace_id']);
+        $this->assertFalse($result['retryable']);
+    }
+
+    public function test_provider_error_response(): void
+    {
+        Http::fake([
+            '*' => Http::response([
+                'success' => false,
+                'status' => 'ERROR',
+                'message' => 'SICFE error',
+                'provider' => [
+                    'codigo' => 5,
+                    'descripcion' => 'RUC no registrado',
+                ],
+                'retryable' => false,
+                'trace_id' => 'error-trace',
+            ], 200),
+        ]);
+
+        $response = Http::get('https://example.com/test');
+        $result = $this->processor->process($response);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals('ERROR', $result['status']);
+        $this->assertEquals(5, $result['provider']['codigo']);
+        $this->assertEquals('RUC no registrado', $result['provider']['descripcion']);
+        $this->assertFalse($result['retryable']);
+        $this->assertNull($result['cfe']);
+    }
+
+    public function test_http_server_error_is_retryable(): void
+    {
+        Http::fake([
+            '*' => Http::response('Internal Server Error', 500),
+        ]);
+
+        $response = Http::get('https://example.com/test');
+        $result = $this->processor->process($response);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals('ERROR', $result['status']);
+        $this->assertTrue($result['retryable']);
+        $this->assertStringContains('HTTP 500', $result['message']);
+    }
+
+    public function test_http_client_error_is_not_retryable(): void
+    {
+        Http::fake([
+            '*' => Http::response('Bad Request', 400),
+        ]);
+
+        $response = Http::get('https://example.com/test');
+        $result = $this->processor->process($response);
+
+        $this->assertFalse($result['success']);
+        $this->assertFalse($result['retryable']);
+    }
+
+    public function test_malformed_json_response(): void
+    {
+        Http::fake([
+            '*' => Http::response('not json at all', 200),
+        ]);
+
+        $response = Http::get('https://example.com/test');
+        $result = $this->processor->process($response);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals('ERROR', $result['status']);
+        $this->assertTrue($result['retryable']);
+        $this->assertStringContains('Malformed response', $result['message']);
+    }
+
+    private function assertStringContains(string $needle, string $haystack): void
+    {
+        $this->assertTrue(
+            str_contains($haystack, $needle),
+            "Failed asserting that '{$haystack}' contains '{$needle}'"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- **Client.php**: HTTP adapter for xml-cfe service with `emit()` and `status()` methods, using bearer token auth, configurable timeout/SSL
- **Mapper.php**: Transforms Invoice Ninja invoice/client/company into the CFE request contract:
  - Resolves tipo_cfe (101 e-Ticket vs 111 e-Factura) based on client RUT
  - Config-driven tax rate → IndFact mapping with explicit failure on unmapped rates
  - Full emisor/receptor/items/meta mapping with monetary normalization
  - Idempotency key from company_key:invoice_id:updated_at
- **ResponseProcessor.php**: Normalizes all response shapes (success, provider error, HTTP failure, malformed JSON) into consistent internal array

## Test plan
- [ ] Unit tests for Client: emit sends POST with auth, status sends GET, timeout handling
- [ ] Unit tests for Mapper: 101/111 type selection, all IndFact mappings, unmapped rate throws, full payload structure
- [ ] Unit tests for ResponseProcessor: success, provider error, 5xx retryable, 4xx non-retryable, malformed JSON

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CFE Uy electronic invoicing standard for emitting invoices and tracking status
  * Implemented automatic invoice payload conversion for service compliance
  * Added response handling and error detection for external service communications

* **Tests**
  * Added comprehensive unit test coverage for CFE Uy integration scenarios including authentication, timeouts, and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->