### PR TITLE
CFE_UY: Support e-document download in CreateEDocument

### DIFF
--- a/app/Jobs/EDocument/CreateEDocument.php
+++ b/app/Jobs/EDocument/CreateEDocument.php
@@ -71,6 +71,19 @@ class CreateEDocument implements ShouldQueue
 
         if ($this->document instanceof Invoice) {
             switch ($e_document_type) {
+                case "CFE_UY":
+                    // Return latest signed XML from cfe_logs if available
+                    $latestLog = $this->document->cfe_logs()
+                        ->whereNotNull('xml_firmado')
+                        ->where('provider_status', 'EN')
+                        ->first();
+
+                    if ($latestLog && $latestLog->xml_firmado) {
+                        return $latestLog->xml_firmado;
+                    }
+
+                    // Fallback: return a minimal XML representation indicating CFE not yet emitted
+                    return '<?xml version="1.0" encoding="UTF-8"?><CFE_UY><status>not_emitted</status><invoice_number>' . htmlspecialchars($this->document->number ?? '') . '</invoice_number></CFE_UY>';
                 case "PEPPOL":
                     return (new Peppol($this->document))->run()->toXml();
                 case "FACT1":


### PR DESCRIPTION
## Summary
- Adds `CFE_UY` case in `CreateEDocument` invoice switch statement
- When signed XML exists in `cfe_logs` (provider_status=EN), returns that XML
- When CFE not yet emitted, returns a minimal XML placeholder with invoice number
- Existing e-document types completely unchanged

## Test plan
- [ ] `download_e_invoice` returns signed XML for emitted CFE_UY invoices
- [ ] `download_e_invoice` returns fallback XML for non-emitted CFE_UY invoices
- [ ] Existing PEPPOL/Verifactu/Zugferd download paths unaffected

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)