### PR TITLE
CFE_UY: Wire send-email gating and retry hooks

### DIFF
--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -321,6 +321,9 @@ class BaseModel extends Model
             elseif($this->company->verifactuEnabled()) {
                 $this->service()->sendVerifactu();
             }
+            elseif($this->company->cfeUyEnabled()) {
+                $this->service()->sendCfeUy();
+            }
         }
 
     }

--- a/app/Services/Invoice/TriggeredActions.php
+++ b/app/Services/Invoice/TriggeredActions.php
@@ -62,6 +62,9 @@ class TriggeredActions extends AbstractService
             if ($this->invoice->company->verifactuEnabled() && !$this->invoice->hasSentAeat()) {
                 $this->invoice->invitations()->update(['email_error' => 'primed']); // Flag the invitations as primed for AEAT submission
                 $this->invoice->service()->sendVerifactu();
+            } elseif ($this->invoice->company->cfeUyEnabled() && !$this->invoice->hasSentAeat()) {
+                $this->invoice->invitations()->update(['email_error' => 'primed']);
+                $this->invoice->service()->sendCfeUy();
             } else {
                 $this->sendEmail();
             }
@@ -95,6 +98,8 @@ class TriggeredActions extends AbstractService
                 \App\Services\EDocument\Jobs\SendEDocument::dispatch(get_class($this->invoice), $this->invoice->id, $this->invoice->company->db);
             } elseif ($this->invoice->company->verifactuEnabled()) {
                 $this->invoice->service()->sendVerifactu();
+            } elseif ($this->invoice->company->cfeUyEnabled()) {
+                $this->invoice->service()->sendCfeUy();
             }
         }
 


### PR DESCRIPTION
## Summary
- **TriggeredActions send_email**: CFE_UY companies now prime invitations (`email_error=primed`) and dispatch `sendCfeUy()` instead of sending email directly - email only sent after successful CFE emission
- **TriggeredActions retry_e_send**: Adds `cfeUyEnabled()` branch to route retries to `sendCfeUy()`
- **BaseModel sent-event hook**: Adds `cfeUyEnabled()` branch to dispatch CFE emission on invoice sent event
- All three hooks mirror the existing Verifactu gating pattern exactly
- PEPPOL and Verifactu behavior completely unchanged

## Test plan
- [ ] CFE_UY company: email is NOT sent before successful CFE emission
- [ ] CFE_UY company: email IS sent after successful CFE emission (primed release)
- [ ] Non-CFE companies: send behavior completely unaffected
- [ ] Retry endpoint dispatches correct job for CFE_UY
- [ ] Sent-event hook dispatches CFE_UY emission

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)