### PR TITLE
CFE_UY: fix mapper contract fields and document numbering

### DIFF
--- a/app/Services/EDocument/Standards/CfeUy/Mapper.php
+++ b/app/Services/EDocument/Standards/CfeUy/Mapper.php
@@ -65,10 +65,7 @@ class Mapper
      */
     public function resolveTipoCfe(): int
     {
-        $vat_number = $this->client->vat_number ?? '';
-        $id_number = $this->client->id_number ?? '';
-
-        if (strlen($vat_number) >= 12 || strlen($id_number) >= 12) {
+        if ($this->hasRuc()) {
             return 111;
         }
 
@@ -83,6 +80,7 @@ class Mapper
         return [
             'tipo_cfe' => $this->resolveTipoCfe(),
             'serie' => 'A',
+            'numero' => $this->resolveDocumentNumber(),
             'fecha_emision' => $this->invoice->date ?? now()->format('Y-m-d'),
             'forma_pago' => $this->resolveFormaPago(),
             'fecha_vencimiento' => $this->invoice->due_date,
@@ -144,9 +142,13 @@ class Mapper
      */
     private function mapReceptor(): array
     {
+        $docNumero = $this->normalizeDocNumber();
+        $countryCode = $this->client->country ? $this->client->country->iso_3166_2 : 'UY';
+
         $receptor = [
-            'tipo_doc_receptor' => $this->resolveReceptorDocType(),
-            'doc_receptor' => $this->client->vat_number ?: ($this->client->id_number ?: ''),
+            'tipo_doc' => $this->resolveReceptorDocType(),
+            'cod_pais' => $countryCode ?: 'UY',
+            'doc_numero' => $docNumero,
             'razon_social' => $this->client->present()->name(),
             'direccion' => trim(implode(', ', array_filter([
                 $this->client->address1 ?? '',
@@ -156,7 +158,7 @@ class Mapper
             ]))),
             'ciudad' => $this->client->city ?? '',
             'departamento' => $this->client->state ?? '',
-            'pais_receptor' => $this->client->country ? $this->client->country->iso_3166_3 : 'URY',
+            'pais' => $this->client->country ? $this->client->country->name : 'Uruguay',
         ];
 
         return $receptor;
@@ -168,13 +170,11 @@ class Mapper
      */
     private function resolveReceptorDocType(): int
     {
-        $vat = $this->client->vat_number ?? '';
-
-        if (strlen($vat) >= 12) {
+        if ($this->hasRuc()) {
             return 2; // RUC
         }
 
-        $id = $this->client->id_number ?? '';
+        $id = preg_replace('/\D+/', '', (string) ($this->client->id_number ?? ''));
         if (strlen($id) >= 6 && strlen($id) <= 8) {
             return 3; // CI
         }
@@ -250,5 +250,47 @@ class Mapper
             'invoice_number' => $this->invoice->number,
             'environment' => app()->environment(),
         ];
+    }
+
+    /**
+     * Resolve CFE document number (required by xml-cfe contract).
+     */
+    private function resolveDocumentNumber(): int
+    {
+        $invoiceNumber = preg_replace('/\D+/', '', (string) ($this->invoice->number ?? ''));
+
+        if ($invoiceNumber !== '' && (int) $invoiceNumber > 0) {
+            return (int) $invoiceNumber;
+        }
+
+        return max(1, (int) $this->invoice->id);
+    }
+
+    /**
+     * Normalize client document number while preserving non-empty fallback values.
+     */
+    private function normalizeDocNumber(): string
+    {
+        if ($this->hasRuc()) {
+            return preg_replace('/\D+/', '', (string) $this->client->vat_number);
+        }
+
+        $idRaw = trim((string) ($this->client->id_number ?? ''));
+        $idDigits = preg_replace('/\D+/', '', $idRaw);
+
+        if ($idDigits !== '') {
+            return $idDigits;
+        }
+
+        return $idRaw;
+    }
+
+    /**
+     * Determine whether the client has a valid-length RUC-like identifier.
+     */
+    private function hasRuc(): bool
+    {
+        $vatDigits = preg_replace('/\D+/', '', (string) ($this->client->vat_number ?? ''));
+        return strlen($vatDigits) >= 12;
     }
 }

--- a/tests/Feature/EInvoice/CfeUy/CfeUyFeatureTest.php
+++ b/tests/Feature/EInvoice/CfeUy/CfeUyFeatureTest.php
@@ -155,10 +155,11 @@ class CfeUyFeatureTest extends TestCase
         $payload = $mapper->toPayload();
 
         $this->assertEquals(111, $payload['document']['tipo_cfe']);
+        $this->assertArrayHasKey('numero', $payload['document']);
         $this->assertEquals($this->invoice->hashed_id, $payload['external_invoice_id']);
         $this->assertNotEmpty($payload['idempotency_key']);
         $this->assertNotEmpty($payload['emisor']['rut']);
-        $this->assertEquals('214100010018', $payload['receptor']['doc_receptor']);
+        $this->assertEquals('214100010018', $payload['receptor']['doc_numero']);
     }
 
     public function test_response_processor_handles_success(): void

--- a/tests/Unit/CfeUy/MapperTest.php
+++ b/tests/Unit/CfeUy/MapperTest.php
@@ -109,7 +109,10 @@ class MapperTest extends TestCase
 
         $this->assertEquals($this->invoice->hashed_id, $payload['external_invoice_id']);
         $this->assertArrayHasKey('tipo_cfe', $payload['document']);
+        $this->assertArrayHasKey('numero', $payload['document']);
         $this->assertArrayHasKey('rut', $payload['emisor']);
         $this->assertArrayHasKey('razon_social', $payload['receptor']);
+        $this->assertArrayHasKey('cod_pais', $payload['receptor']);
+        $this->assertArrayHasKey('doc_numero', $payload['receptor']);
     }
 }


### PR DESCRIPTION
## Summary
Follow-up fixes on top of `v5-stable` CFE_UY implementation to align Ninja mapper payload with `xml-cfe` normalized input contract.

## Changes
- `Mapper::resolveTipoCfe()` now classifies `111` only from RUC presence (vat number), not generic id_number length.
- Added required `document.numero` in mapped payload.
- Aligned receptor payload keys to normalized model:
  - `tipo_doc` (was `tipo_doc_receptor`)
  - `cod_pais` ISO-2 (was ISO-3 `pais_receptor`)
  - `doc_numero` (was `doc_receptor`)
  - `pais` string
- Added normalization helpers for RUC/document number.
- Updated affected tests:
  - `tests/Unit/CfeUy/MapperTest.php`
  - `tests/Feature/EInvoice/CfeUy/CfeUyFeatureTest.php`

## Why
This prevents request-contract mismatches that can cause SICFE submission failures despite the CFE_UY feature being merged.

## Validation
I could not run PHPUnit in this environment because `php` is not installed in the shell. Test updates were made to match the new payload keys and required document field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced electronic document processing and type resolution logic for improved accuracy.
  * Improved receptor data mapping with streamlined field organization and cleaner naming conventions.
  * Added document number tracking to electronic documents for better identification and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->